### PR TITLE
Add scrollable letter dials for word creation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,18 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import LetterDial from './LetterDial';
 
 export default function App() {
+  const dials = Array.from({ length: 5 });
   return (
     <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
+      <View style={styles.row}>
+        {dials.map((_, i) => (
+          <View key={i} style={styles.dial}>
+            <LetterDial />
+          </View>
+        ))}
+      </View>
       <StatusBar style="auto" />
     </View>
   );
@@ -16,5 +24,17 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  dial: {
+    width: 60,
+    height: 60,
+    marginHorizontal: 4,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    overflow: 'hidden',
   },
 });

--- a/LetterDial.tsx
+++ b/LetterDial.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
+
+const LETTERS = Array.from({ length: 26 }, (_, i) => String.fromCharCode(65 + i));
+const ITEM_HEIGHT = 60;
+
+interface Props {
+  initialLetter?: string;
+  onChange?: (letter: string) => void;
+}
+
+export default function LetterDial({ initialLetter = 'A', onChange }: Props) {
+  const scrollRef = useRef<ScrollView>(null);
+  const [current, setCurrent] = useState(initialLetter.toUpperCase());
+
+  useEffect(() => {
+    const index = LETTERS.indexOf(current);
+    if (index >= 0) {
+      scrollRef.current?.scrollTo({ y: index * ITEM_HEIGHT, animated: false });
+    }
+  }, [current]);
+
+  const handleMomentumEnd = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const index = Math.round(e.nativeEvent.contentOffset.y / ITEM_HEIGHT);
+    const letter = LETTERS[index] || 'A';
+    setCurrent(letter);
+    onChange?.(letter);
+  };
+
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        ref={scrollRef}
+        showsVerticalScrollIndicator={false}
+        snapToInterval={ITEM_HEIGHT}
+        decelerationRate="fast"
+        onMomentumScrollEnd={handleMomentumEnd}
+      >
+        {LETTERS.map((letter) => (
+          <View key={letter} style={styles.item}>
+            <Text style={styles.letter}>{letter}</Text>
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: ITEM_HEIGHT,
+    width: '100%',
+    overflow: 'hidden',
+  },
+  item: {
+    height: ITEM_HEIGHT,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  letter: {
+    fontSize: 32,
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
## Summary
- Replace default screen with five side-by-side letter dials
- Implement reusable `LetterDial` component for vertical alphabet scrolling

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f6763dae48328bc88d375f704e86e