### PR TITLE
Randomize starting letters from word list

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,15 +1,22 @@
+import React, { useMemo } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, View } from 'react-native';
 import LetterDial from './src/components/LetterDial';
+import { COMMON_FIVE_LETTER_WORDS } from './src/data/fiveLetterWords';
 
 export default function App() {
-  const dials = Array.from({ length: 5 });
+  const randomWord = useMemo(() => {
+    const index = Math.floor(Math.random() * COMMON_FIVE_LETTER_WORDS.length);
+    return COMMON_FIVE_LETTER_WORDS[index].toUpperCase();
+  }, []);
+  const letters = randomWord.split('');
+
   return (
     <View style={styles.container}>
       <View style={styles.row}>
-        {dials.map((_, i) => (
+        {letters.map((letter, i) => (
           <View key={i} style={styles.dial}>
-            <LetterDial />
+            <LetterDial initialLetter={letter} />
           </View>
         ))}
       </View>


### PR DESCRIPTION
## Summary
- Select a random word from `COMMON_FIVE_LETTER_WORDS` when the app mounts
- Initialize each letter dial with the corresponding letter from that word

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f7858fb1c8328b2300c09ed9934f3