### PR TITLE
feat: add word ladder step counter

### DIFF
--- a/src/utils/wordLadder.ts
+++ b/src/utils/wordLadder.ts
@@ -1,0 +1,60 @@
+import { longFiveLetterWords } from "../data/longFiveLetterWords";
+
+/**
+ * Compute the minimum number of single-letter transformations required to
+ * change `start` into `end` where every intermediate word must appear in
+ * `longFiveLetterWords`.
+ *
+ * Returns `null` if no such transformation exists.
+ */
+export function stepsBetweenWords(start: string, end: string): number | null {
+  const normalizedStart = start.toLowerCase();
+  const normalizedEnd = end.toLowerCase();
+
+  if (normalizedStart.length !== normalizedEnd.length) {
+    throw new Error("Words must have the same length");
+  }
+
+  if (normalizedStart === normalizedEnd) {
+    return 0;
+  }
+
+  const dictionary = new Set(longFiveLetterWords.map((w) => w.toLowerCase()));
+  // Ensure start and end words are in the dictionary so they can be part of the path
+  dictionary.add(normalizedStart);
+  dictionary.add(normalizedEnd);
+
+  const visited = new Set<string>([normalizedStart]);
+  const queue: Array<{ word: string; steps: number }> = [
+    { word: normalizedStart, steps: 0 },
+  ];
+
+  const alphabet = Array.from({ length: 26 }, (_, i) =>
+    String.fromCharCode(97 + i),
+  );
+
+  while (queue.length) {
+    const { word, steps } = queue.shift()!;
+
+    for (let i = 0; i < word.length; i++) {
+      for (const letter of alphabet) {
+        if (letter === word[i]) continue;
+        const nextWord = word.slice(0, i) + letter + word.slice(i + 1);
+
+        if (!dictionary.has(nextWord) || visited.has(nextWord)) {
+          continue;
+        }
+
+        if (nextWord === normalizedEnd) {
+          return steps + 1;
+        }
+
+        visited.add(nextWord);
+        queue.push({ word: nextWord, steps: steps + 1 });
+      }
+    }
+  }
+
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- implement BFS-based stepsBetweenWords utility to count minimal letter-change steps

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a4b566e6b083289e2f9fd1b7dce501