### PR TITLE
Restrict dial changes to one letter and add reset button

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,16 +7,21 @@ import { randomWordPairTwoStepsApart } from './src/utils/wordLadder';
 
 export default function App() {
   const { start, end } = useMemo(() => randomWordPairTwoStepsApart(), []);
+  const [baseLetters, setBaseLetters] = useState(() => start.split(''));
   const [letters, setLetters] = useState(() => start.split(''));
   const [words, setWords] = useState<string[]>([]);
   const [hasWon, setHasWon] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
 
   const handleLetterChange = (index: number, letter: string) => {
-    setLetters(prev => {
-      const updated = [...prev];
-      updated[index] = letter;
-      return updated;
-    });
+    const updated = [...letters];
+    updated[index] = letter;
+    setLetters(updated);
+    const diffs = updated.reduce<number[]>((acc, l, i) => {
+      if (l !== baseLetters[i]) acc.push(i);
+      return acc;
+    }, []);
+    setActiveIndex(diffs.length ? diffs[0] : null);
   };
 
   const handleSubmit = () => {
@@ -25,6 +30,13 @@ export default function App() {
     if (word === end) {
       setHasWon(true);
     }
+    setBaseLetters([...letters]);
+    setActiveIndex(null);
+  };
+
+  const handleReset = () => {
+    setLetters(baseLetters);
+    setActiveIndex(null);
   };
 
   return (
@@ -50,11 +62,16 @@ export default function App() {
                 <LetterDial
                   initialLetter={letter}
                   onChange={l => handleLetterChange(i, l)}
+                  disabled={activeIndex !== null && activeIndex !== i}
                 />
               </View>
             ))}
           </View>
-          <Button title="Submit" onPress={handleSubmit} />
+          <View style={styles.buttonRow}>
+            <Button title="Reset" onPress={handleReset} />
+            <View style={styles.buttonSpacer} />
+            <Button title="Submit" onPress={handleSubmit} />
+          </View>
         </View>
 
         <StatusBar style="auto" />
@@ -103,5 +120,13 @@ const styles = StyleSheet.create({
     height: 180,
     marginHorizontal: 4,
     overflow: 'hidden',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  buttonSpacer: {
+    width: 16,
   },
 });

--- a/src/components/LetterDial.tsx
+++ b/src/components/LetterDial.tsx
@@ -19,9 +19,14 @@ const EXTENDED_LETTERS = Array.from(
 interface Props {
   initialLetter?: string;
   onChange?: (letter: string) => void;
+  disabled?: boolean;
 }
 
-export default function LetterDial({ initialLetter = 'A', onChange }: Props) {
+export default function LetterDial({
+  initialLetter = 'A',
+  onChange,
+  disabled = false,
+}: Props) {
   const scrollRef = useRef<ScrollView>(null);
   const startIndex =
     LETTERS.indexOf(initialLetter.toUpperCase()) + LETTERS.length;
@@ -32,6 +37,7 @@ export default function LetterDial({ initialLetter = 'A', onChange }: Props) {
       y: (startIndex - 1) * ITEM_HEIGHT,
       animated: false,
     });
+    setCurrentIndex(startIndex);
   }, [startIndex]);
 
   const handleScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -58,32 +64,46 @@ export default function LetterDial({ initialLetter = 'A', onChange }: Props) {
   };
 
   return (
-    <View style={styles.wrapper}>
+    <View style={[styles.wrapper, disabled && styles.disabled]}>
       <View style={styles.container}>
-        <View style={[styles.item, styles.selectedItem, { position: 'absolute', top: ITEM_HEIGHT, left: 0, right: 0, zIndex: 1, pointerEvents: 'none' }]} />
+        <View
+          style={[
+            styles.item,
+            styles.selectedItem,
+            {
+              position: 'absolute',
+              top: ITEM_HEIGHT,
+              left: 0,
+              right: 0,
+              zIndex: 1,
+              pointerEvents: 'none',
+            },
+          ]}
+        />
         <ScrollView
           ref={scrollRef}
           showsVerticalScrollIndicator={false}
           snapToInterval={ITEM_HEIGHT}
           decelerationRate="fast"
           onScroll={e => {
-            handleScroll(e); 
+            handleScroll(e);
           }}
           onMomentumScrollEnd={handleMomentumEnd}
+          scrollEnabled={!disabled}
           scrollEventThrottle={16}
         >
           {EXTENDED_LETTERS.map((letter, i) => {
             const isSelected = i === currentIndex;
             return (
-              <View
-          key={`${letter}-${i}`}
-          style={styles.item}
-              >
-          <Text
-            style={[styles.letter, isSelected ? styles.selected : styles.adjacent]}
-          >
-            {letter}
-          </Text>
+              <View key={`${letter}-${i}`} style={styles.item}>
+                <Text
+                  style={[
+                    styles.letter,
+                    isSelected ? styles.selected : styles.adjacent,
+                  ]}
+                >
+                  {letter}
+                </Text>
               </View>
             );
           })}
@@ -120,5 +140,8 @@ const styles = StyleSheet.create({
   },
   adjacent: {
     color: '#aaa',
+  },
+  disabled: {
+    opacity: 0.3,
   },
 });


### PR DESCRIPTION
## Summary
- enforce only one dial change from the current word, disabling other dials
- add a reset control to restore dials to the last submitted word
- visually indicate disabled dials by greying them out

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a4df76b44483289e3807c7e243223d